### PR TITLE
bs4: Specify the markup type for HTML explicitly.

### DIFF
--- a/pyoembed/providers/autodiscover.py
+++ b/pyoembed/providers/autodiscover.py
@@ -29,7 +29,7 @@ class AutoDiscoverProvider(BaseProvider):
             raise ProviderException('Failed to auto-discover oEmbed provider '
                                     'for url: %s' % url)
 
-        bs = BeautifulSoup(response.text)
+        bs = BeautifulSoup(response.text, 'lxml')
 
         # we prefer json over xml, so let's try it first :)
         oembed_url = bs.find('link', type='application/json+oembed', href=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-requests
 beautifulsoup4
+lxml
+requests


### PR DESCRIPTION
This fixes the following warning when using this library:

```
/srv/zulip-py3-venv/lib/python3.5/site-packages/bs4/__init__.py:185:
UserWarning: No parser was explicitly specified, so I'm using the best
available HTML parser for this system ("lxml"). This usually isn't a
problem, but if you run this code on another system, or in a different
virtual environment, it may use a different parser and behave
differently.

The code that caused this warning is on line 376 of the file
/home/tabbott/zulip/tools/test-backend. To get rid of this warning,
change code that looks like this:

 BeautifulSoup(YOUR_MARKUP)

to this:

 BeautifulSoup(YOUR_MARKUP, "lxml")
```