### PR TITLE
load providers from providers.json

### DIFF
--- a/pyoembed/providers/from_spec.py
+++ b/pyoembed/providers/from_spec.py
@@ -1,0 +1,77 @@
+import re
+from collections import OrderedDict
+try:
+    from urllib import urlencode
+except ImportError:
+    from urllib.parse import urlencode
+try:
+    from urlparse import parse_qsl, urlsplit, urlunsplit
+except ImportError:
+    from urllib.parse import parse_qsl, urlsplit, urlunsplit
+
+import requests
+
+from pyoembed.providers import BaseProvider
+
+
+def transform_pattern(pattern):
+    if pattern[-1] == '*':
+        pattern = pattern[:-1] + r'.+'
+    return r'[^/]+'.join(pattern.split('*'))
+
+
+TESTS = {}
+INFO = {}
+
+
+def load_data(reload=False):
+    global TESTS, INFO
+    if TESTS and not reload:
+        return
+    r = requests.get('http://oembed.com/providers.json')
+    assert r.ok
+    for provider_info in r.json():
+        name = provider_info['provider_name']
+        INFO[name] = provider_info
+        for endpoint in provider_info['endpoints']:
+            for scheme in endpoint.get('schemes', []):
+                TESTS[re.compile(transform_pattern(scheme))] = name
+
+
+class FromSpecProvider(BaseProvider):
+
+    priority = 1000  # Not quite the last
+
+    # following properties are not used because we are overriding all the
+    # methods that used them.
+    oembed_endpoint = None
+    oembed_schemas = None
+
+    def __init__(self):
+        load_data()
+
+    def url_supported(self, url):
+        global TESTS
+        for test in TESTS.keys():
+            if test.match(url):
+                return True
+        return False
+
+    def oembed_url(self, url):
+        global TESTS, INFO
+        for test, name in TESTS.items():
+            if test.match(url):
+                info = INFO[name]
+                endpoints = info['endpoints']
+                if len(endpoints) > 1:
+                    endpoints = [
+                        e for e in endpoints if test.pattern in [
+                            transform_pattern(s) for s in e.get('schemes', [])]]
+                if len(endpoints):
+                    oembed_endpoint = endpoints[0]['url']
+                    oembed_endpoint = oembed_endpoint.replace('{format}', 'json')
+                    scheme, netloc, path, qs, fragment = urlsplit(oembed_endpoint)
+                    query_params = OrderedDict(parse_qsl(qs))
+                    query_params['url'] = url
+                    return urlunsplit((scheme, netloc, path,
+                                       urlencode(query_params, True), fragment))

--- a/pyoembed/tests/providers/test_from_spec.py
+++ b/pyoembed/tests/providers/test_from_spec.py
@@ -1,0 +1,25 @@
+import mock
+import unittest
+
+from pyoembed.exceptions import ProviderException
+from pyoembed.providers.from_spec import FromSpecProvider
+from pyoembed.tests import get_fixture
+
+
+class AutoDiscoverProviderTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.provider = FromSpecProvider()
+        self.url = 'https://www.youtube.com/watch?v=2nLsvPBqeZ8'
+
+    def test_url_supported(self):
+        self.assertTrue(self.provider.url_supported(self.url))
+
+    @mock.patch('pyoembed.providers.from_spec.requests.get')
+    def test_oembed_url_json(self, get):
+        get.return_value = response = mock.Mock()
+        response.ok = True
+        response.json = get_fixture('youtube.json')
+        self.assertEqual(self.provider.oembed_url(self.url),
+                         'https://www.youtube.com/oembed?url=https%3A%2F%2F'
+                         'www.youtube.com%2Fwatch%3Fv%3D2nLsvPBqeZ8')

--- a/pyoembed/tests/providers/test_main.py
+++ b/pyoembed/tests/providers/test_main.py
@@ -32,7 +32,7 @@ class BaseProviderTestCase(unittest.TestCase):
     def test_build_re(self):
         provider = MyProvider()
         _re = provider._build_re('http://google.com/*/foo')
-        self.assertEqual(_re.pattern, '^http\\:\\/\\/google\\.com\\/.*\\/foo$')
+        self.assertEqual(_re.pattern, r'^http://google\.com/.*/foo$')
 
     def test_get_re(self):
         provider = MyProvider()
@@ -40,9 +40,9 @@ class BaseProviderTestCase(unittest.TestCase):
         self.assertEqual(len(_re), 2)
         self.assertEqual(_re[0].pattern, 'http://bola\.com/guda/.*')
         self.assertEqual(_re[1].pattern,
-                         '^http\\:\\/\\/google\\.com\\/.*\\/foo$')
+                         r'^http://google\.com/.*/foo$')
         self.assertEqual(len(provider._re_schemas), 2)
         self.assertEqual(provider._re_schemas[0].pattern,
-                         'http://bola\.com/guda/.*')
+                         r'http://bola\.com/guda/.*')
         self.assertEqual(provider._re_schemas[1].pattern,
-                         '^http\\:\\/\\/google\\.com\\/.*\\/foo$')
+                         r'^http://google\.com/.*/foo$')


### PR DESCRIPTION
I thought we could use `http://oembed.com/providers.json` as a live reference to oembed implementations, which would be a most common case before the final fallback.
