### PR TITLE
Let BeautifulSoup detect charset from <meta> if not given in headers

### DIFF
--- a/pyoembed/providers/autodiscover.py
+++ b/pyoembed/providers/autodiscover.py
@@ -1,3 +1,5 @@
+import cgi
+
 import requests
 from bs4 import BeautifulSoup
 
@@ -29,7 +31,13 @@ class AutoDiscoverProvider(BaseProvider):
             raise ProviderException('Failed to auto-discover oEmbed provider '
                                     'for url: %s' % url)
 
-        bs = BeautifulSoup(response.text, 'lxml')
+        content_type = response.headers.get('Content-Type')
+        if content_type is None:
+            charset = None
+        else:
+            mime_type, parameters = cgi.parse_header(content_type)
+            charset = parameters.get('charset')
+        bs = BeautifulSoup(response.content, 'lxml', from_encoding=charset)
 
         # we prefer json over xml, so let's try it first :)
         oembed_url = bs.find('link', type='application/json+oembed', href=True)

--- a/pyoembed/tests/__init__.py
+++ b/pyoembed/tests/__init__.py
@@ -4,5 +4,5 @@ import os
 def get_fixture(filename):
     cwd = os.path.dirname(os.path.abspath(__file__))
     fixture = os.path.join(cwd, 'fixtures', filename)
-    with open(fixture) as fp:
+    with open(fixture, 'rb') as fp:
         return fp.read()

--- a/pyoembed/tests/providers/test_autodiscover.py
+++ b/pyoembed/tests/providers/test_autodiscover.py
@@ -19,7 +19,7 @@ class AutoDiscoverProviderTestCase(unittest.TestCase):
     def test_oembed_url_request_failed(self, get):
         get.return_value = response = mock.Mock()
         response.ok = False
-        response.text = get_fixture('autodiscover-both.html')
+        response.content = get_fixture('autodiscover-both.html')
         with self.assertRaises(ProviderException):
             self.provider.oembed_url(self.url)
 
@@ -27,7 +27,8 @@ class AutoDiscoverProviderTestCase(unittest.TestCase):
     def test_oembed_url_none(self, get):
         get.return_value = response = mock.Mock()
         response.ok = True
-        response.text = get_fixture('autodiscover-none.html')
+        response.headers = {}
+        response.content = get_fixture('autodiscover-none.html')
         with self.assertRaises(ProviderException):
             self.provider.oembed_url(self.url)
 
@@ -35,7 +36,8 @@ class AutoDiscoverProviderTestCase(unittest.TestCase):
     def test_oembed_url_both(self, get):
         get.return_value = response = mock.Mock()
         response.ok = True
-        response.text = get_fixture('autodiscover-both.html')
+        response.headers = {}
+        response.content = get_fixture('autodiscover-both.html')
         self.assertEqual(self.provider.oembed_url(self.url),
                          'http://www.youtube.com/oembed?url=http%3A%2F%2F'
                          'www.youtube.com%2Fwatch%3Fv%3D2nLsvPBqeZ8'
@@ -45,7 +47,8 @@ class AutoDiscoverProviderTestCase(unittest.TestCase):
     def test_oembed_url_json(self, get):
         get.return_value = response = mock.Mock()
         response.ok = True
-        response.text = get_fixture('autodiscover-json.html')
+        response.headers = {}
+        response.content = get_fixture('autodiscover-json.html')
         self.assertEqual(self.provider.oembed_url(self.url),
                          'http://www.youtube.com/oembed?url=http%3A%2F%2F'
                          'www.youtube.com%2Fwatch%3Fv%3D2nLsvPBqeZ8'
@@ -55,7 +58,8 @@ class AutoDiscoverProviderTestCase(unittest.TestCase):
     def test_oembed_url_xml(self, get):
         get.return_value = response = mock.Mock()
         response.ok = True
-        response.text = get_fixture('autodiscover-xml.html')
+        response.headers = {}
+        response.content = get_fixture('autodiscover-xml.html')
         self.assertEqual(self.provider.oembed_url(self.url),
                          'http://www.youtube.com/oembed?url=http%3A%2F%2F'
                          'www.youtube.com%2Fwatch%3Fv%3D2nLsvPBqeZ8'


### PR DESCRIPTION
An HTML document sent without a charset in the Content-Type header needs to be scanned for a charset in `<meta>` tags. We need to pass bytes instead of Unicode to Beautiful Soup to allow it to do this.